### PR TITLE
Don't use str for inner classes in nested JSONs

### DIFF
--- a/docs/payloadvalidators.rst
+++ b/docs/payloadvalidators.rst
@@ -21,15 +21,9 @@ must be initialized and should be a an object of one of the classes of
 Validating Nested JSON
 ----------------------
 
-Validating nested JSON is similar to how you validate payloads without nested
-JSON. What you do is that you write a separate validator for nested JSON as
-well and use the :class:`incoming.datatypes.JSON` datatype to tell incoming
-to use another validator for the nested JSON.
-
-Global Validator Class for Nested JSON
-++++++++++++++++++++++++++++++++++++++
-
-Here is an example of writing validators for nested JSON::
+Validating nested JSON is similar to how you validate other payloads. Simply,
+write a validator for each JSON and then use the
+:class:`incoming.datatypes.JSON` datatype to validate the nested JSON::
 
     >>> class AddressValidator(PayloadValidator):
     ...     street = datatypes.String()
@@ -46,31 +40,24 @@ Here is an example of writing validators for nested JSON::
     >>> PersonValidator().validate(dict(name='Some name', age=19, address=dict(street='Brannan, SF', country=0)))
     (False, {'address': ['Invalid data. Expected JSON.', {'country': ['Invalid data. Expected a string.']}]})
 
-Nested Validator Class for Nested JSON
-++++++++++++++++++++++++++++++++++++++
-
-Here is another way of writing the above example where the ``AddressValidator``
-is a nested class of ``PersonValidator``::
+If you want to use a nested class instead, just remember to define the inner
+class before using it, so that the name of the inner class is available in the
+scope of the parent class::
 
     >>> class PersonValidator(PayloadValidator):
-    ...     name = datatypes.String()
-    ...     age = datatypes.Integer()
-    ...     
-    ...     # Note that the validator class' name is provided as a str value
-    ...     address = datatypes.JSON('AddressValidator')
-    ...     
     ...     class AddressValidator(PayloadValidator):
     ...         street = datatypes.String()
     ...         country = datatypes.String()
+    ...
+    ...     name = datatypes.String()
+    ...     age = datatypes.Integer()
+    ...     address = datatypes.JSON(AddressValidator)
     ...
     >>> PersonValidator().validate(dict(name='Some name', age=19, address=dict(street='Brannan, SF', country='USA')))
     (True, None)
     >>>
     >>> PersonValidator().validate(dict(name='Some name', age=19, address=dict(street='Brannan, SF', country=0)))
     (False, {'address': ['Invalid data. Expected JSON.', {'country': ['Invalid data. Expected a string.']}]})
-
-.. note:: when the validator class is nested, the name of the class must be
-          provided as an :class:`str` value.
 
 Custom error messages for every field
 -------------------------------------

--- a/incoming/datatypes.py
+++ b/incoming/datatypes.py
@@ -213,10 +213,10 @@ class JSON(Types):
     def __init__(self, cls, *args, **kwargs):
         '''
         :param cls: sub-class of :class:`incoming.PayloadValidator` for
-                    validating nested JSON. Class object can be accepted. In
-                    case you want to have the class nested withing the parent
-                    validator, you can pass the name of the class as a string
-                    as well.
+                    validating nested JSON. If you are using a class nested
+                    within the parent validator, you must define the inner
+                    class before using it, so that the name of the inner class
+                    is defined in the scope of the parent class.
         '''
 
         self.cls = cls

--- a/incoming/tests/test_datatypes.py
+++ b/incoming/tests/test_datatypes.py
@@ -125,6 +125,37 @@ class TestFunction(TestCase):
 
 class TestJSON(TestCase):
 
+    def test_json_nested_json(self):
+        class CustomJSONValidator(PayloadValidator):
+            class InnerJSONValidator(PayloadValidator):
+                foo = datatypes.String()
+
+            age = datatypes.Integer()
+            inner = datatypes.JSON(InnerJSONValidator)
+
+        validator = datatypes.JSON(CustomJSONValidator)
+        self.assertEquals(
+            validator.cls.inner.cls.__name__,
+            'InnerJSONValidator',
+        )
+
+        errors = PayloadErrors()
+        result = datatypes.JSON(CustomJSONValidator).validate(
+            dict(age=10, inner=dict(foo='bar')),
+            key='nested',
+            errors=errors['nested'])
+        self.assertTrue(result)
+        self.assertFalse('nested' in errors)
+        self.assertTrue(len(errors.to_dict().keys()) == 0)
+
+        result = datatypes.JSON(CustomJSONValidator).validate(
+            dict(age='10', inner=dict(foo=42)),
+            key='nested',
+            errors=errors['nested'])
+        self.assertFalse(result)
+        self.assertTrue('nested' in errors)
+        self.assertTrue(len(errors.to_dict().keys()) == 1)
+
     def test_json_validates_normal_types(self):
         class CustomJSONValidator(PayloadValidator):
             age = datatypes.Integer()


### PR DESCRIPTION
Python supports inner classes and they work just fine in incoming, it's just a
matter of scoping them correctly :) Also, the documentation shouldn't hint
users to use strings instead because it's not as powerful and it can be
harmful.

For example, using proper classnames, Python will complain at compile time if a
name is wrong. If using strings, the error would go unnoticed until the code
path is executed.